### PR TITLE
Bump to 2025.2 + intellij platform bump to 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [1.2.3] - 2025-08-22
+- Added IDE version 2025.2
+
 ## [1.2.2] - 2025-01-16
 - Added IDE version 2025.1
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id("java")
-    id("org.jetbrains.intellij.platform") version "2.0.0"
+    id("org.jetbrains.intellij.platform") version "2.7.2"
     id("org.kordamp.gradle.markdown") version "2.2.0"
 }
 
@@ -43,7 +43,6 @@ dependencies {
 
         pluginVerifier()
         zipSigner()
-        instrumentationTools()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 pluginSinceBuild = 231
-pluginUntilBuild = 251.*
+pluginUntilBuild = 252.*
 platformType = IC
 platformVersion = 2024.2


### PR DESCRIPTION
instrumentationTools call is deprecated and no longer required.  See https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/75c16fe10c5090296049b4358ee4fa93b14c3fc3/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformDependenciesExtension.kt#L2535